### PR TITLE
Saving User Input to localStorage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import Genre from './data/genre.json';
 
 
 export const App = () => {
-  // Get initial values from localStorage
+  // Get values from localStorage
   let initialDistricts;
   const districtsFromLocalStorage = localStorage.getItem('districts');
   if (districtsFromLocalStorage !== null) {
@@ -37,7 +37,7 @@ export const App = () => {
   const includeChainFromLocalStorage = localStorage.getItem('includeChain');
   if (includeChainFromLocalStorage !== null && includeChainFromLocalStorage === 'false') initialIncludeChain = false;
 
-  // Set states
+  // Set initial states
   const [result, setResult] = useState('');
   const [districts, setDistricts] = useState(Object.keys(District).reduce((res, key) => {
     res[key] = initialDistricts.includes(key);

--- a/src/App.js
+++ b/src/App.js
@@ -11,22 +11,43 @@ import { PageUpdate } from './components/page-update';
 import { Page404 } from './components/404';
 import { ScrollTop } from './components/utils/util-scroll';
 
-import District from "./data/district.json";
-import Genre from "./data/genre.json";
+import District from './data/district.json';
+import Genre from './data/genre.json';
 
 
 export const App = () => {
-  const [result, setResult] = useState("");
+  // Get initial values from localStorage
+  let initialDistricts;
+  const districtsFromLocalStorage = localStorage.getItem('districts');
+  if (districtsFromLocalStorage !== null) {
+    initialDistricts = districtsFromLocalStorage.split(',');
+  } else {
+    initialDistricts = Object.keys(District);
+  }
+
+  let initialGenres;
+  const genresFromLocalStorage = localStorage.getItem('genres');
+  if (genresFromLocalStorage !== null) {
+    initialGenres = genresFromLocalStorage.split(',');
+  } else {
+    initialGenres = Object.keys(Genre);
+  }
+
+  let initialIncludeChain = true;
+  const includeChainFromLocalStorage = localStorage.getItem('includeChain');
+  if (includeChainFromLocalStorage !== null && includeChainFromLocalStorage === 'false') initialIncludeChain = false;
+
+  // Set states
+  const [result, setResult] = useState('');
   const [districts, setDistricts] = useState(Object.keys(District).reduce((res, key) => {
-    res[key] = true;
+    res[key] = initialDistricts.includes(key);
     return res;
   }, {}));
   const [genres, setGenres] = useState(Object.keys(Genre).reduce((res, key) => {
-    res[key] = true;
+    res[key] = initialGenres.includes(key);
     return res;
   }, {}));
-
-  const [includeChain, setIncludeChain] = useState(true);
+  const [includeChain, setIncludeChain] = useState(initialIncludeChain);
 
   return (
     <BrowserRouter basename={process.env.PUBLIC_URL}>

--- a/src/components/page-home.js
+++ b/src/components/page-home.js
@@ -71,9 +71,9 @@ export const PageHome = (
         <br />
         <p className="text-muted mt-1">チェーン店を除外したい場合は「チェーン店を含まない」にしてください。</p>
       </div>
-      <FilterCard name="地区" target={District} states={districts} setStates={setDistricts} />
+      <FilterCard name="地区" id="districts" target={District} states={districts} setStates={setDistricts} />
       <br />
-      <FilterCard name="ジャンル" target={Genre} states={genres} setStates={setGenres} />
+      <FilterCard name="ジャンル" id="genres" target={Genre} states={genres} setStates={setGenres} />
       <hr />
       <h3>More Information</h3>
       <Row className="row-cols-auto justify-content-center">

--- a/src/components/page-home.js
+++ b/src/components/page-home.js
@@ -23,10 +23,13 @@ export const PageHome = (
   { setResult, districts, setDistricts, genres, setGenres, includeChain, setIncludeChain }
 ) => {
   const navigate = useNavigate();
-  const [chainText, setChainText] = useState('チェーン店を含む');
+  const initialChainText = includeChain ? 'チェーン店を含む' : 'チェーン店を含まない';
+  const [chainText, setChainText] = useState(initialChainText);
 
   const changeChain = e => {
     setIncludeChain(e.currentTarget.checked);
+    localStorage.setItem('includeChain', e.currentTarget.checked);
+
     if (includeChain) {
       setChainText('チェーン店を含まない');
     } else {

--- a/src/components/page-home.js
+++ b/src/components/page-home.js
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Button, Col, Row, ToggleButton } from "react-bootstrap";
 import { FaGithub } from "react-icons/fa";
 
@@ -23,18 +22,10 @@ export const PageHome = (
   { setResult, districts, setDistricts, genres, setGenres, includeChain, setIncludeChain }
 ) => {
   const navigate = useNavigate();
-  const initialChainText = includeChain ? 'チェーン店を含む' : 'チェーン店を含まない';
-  const [chainText, setChainText] = useState(initialChainText);
 
   const changeChain = e => {
     setIncludeChain(e.currentTarget.checked);
     localStorage.setItem('includeChain', e.currentTarget.checked);
-
-    if (includeChain) {
-      setChainText('チェーン店を含まない');
-    } else {
-      setChainText('チェーン店を含む');
-    }
   }
 
   const passResult = () => {
@@ -76,7 +67,7 @@ export const PageHome = (
       <Button variant="primary" onClick={passResult} autoFocus={true} >今日のランチを決定！</Button>
       <hr />
       <div>
-        <ToggleButton type="checkbox" id="includeChain" variant="outline-success" checked={includeChain} onChange={changeChain} value="includeChain">{chainText}</ToggleButton>
+        <ToggleButton type="checkbox" id="includeChain" variant="outline-success" checked={includeChain} onChange={changeChain} value="includeChain">{includeChain ? 'チェーン店を含む' : 'チェーン店を含まない'}</ToggleButton>
         <br />
         <p className="text-muted mt-1">チェーン店を除外したい場合は「チェーン店を含まない」にしてください。</p>
       </div>

--- a/src/components/utils/util-filter.js
+++ b/src/components/utils/util-filter.js
@@ -6,20 +6,23 @@ const CheckButton = ({ itemKey, itemName, checked, onChange }) => {
 }
 
 
-export const FilterCard = ({ name, target, states, setStates }) => {
+export const FilterCard = ({ name, id, target, states, setStates }) => {
   const handleChange = e => {
-    setStates({
-      ...states,
-      [e.target.id]: e.target.checked
-    })
+    const newStates = { ...states, [e.target.id]: e.target.checked }
+
+    localStorage.setItem(id, Object.keys(newStates).filter(key => newStates[key]));
+    setStates(newStates);
   }
 
   const selectAll = e => {
     const flg = e.target.name === "all";
-    setStates(Object.keys(target).reduce((res, key) => {
+    const newStates = Object.keys(target).reduce((res, key) => {
       res[key] = flg;
       return res;
-    }, {}));
+    }, {});
+
+    localStorage.setItem(id, Object.keys(newStates).filter(key => newStates[key]));
+    setStates(newStates);
   }
 
   const targetList = Object.keys(target).map(key => {


### PR DESCRIPTION
Thank you for adding the feature to exclude chain restaurants! The convenience has improved! 💖

This pull request introduces the following changes:

1. **Saving User Input to localStorage**: Now, user inputs for `districts`, `genres`, and `includeChain` are saved to `localStorage`. This ensures that even if users reload the top page, their input states are preserved, thereby enhancing the user experience.
2. **UI Text Adjustment**: Modified the loading behavior of the top page to display the text "チェーン店を含まない" right from the start.

I've used an `id` attribute to the `FilterCard`. However, there might be a more appropriate attribute name for this. Please let me know if you have any suggestions or if this is a concern.