### PR TITLE
Fixed errors when reloading the results page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Container } from 'react-bootstrap';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 import './App.css';
 
@@ -44,7 +44,7 @@ export const App = () => {
               setIncludeChain={setIncludeChain}
             />
           } />
-          <Route path="/result" element={result ? <PageResult result={result} /> : <PageHome setResult={setResult} />} />
+          <Route path="/result" element={result ? <PageResult result={result} /> : <Navigate to="/" />} />
           <Route path="/list" element={<PageList />} />
           <Route path="/update" element={<PageUpdate />} />
           <Route path="*" element={<Page404 />} />


### PR DESCRIPTION
When reloading the results page, it throws a console error and the page cannot be displayed, so it has been modified to redirect to the top page.
This was due to a lack of necessary attributes such as `districts`.

<img width="576" alt="image" src="https://github.com/tani-cat/hongo-lunch/assets/11713748/81c635ce-4ac1-4d00-a873-bc25be2381df">
